### PR TITLE
Kode for å lagre og hente inntektsmeldinger

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ val prometheusVersion = "0.5.0"
 val flywayVersion = "6.0.0-beta"
 val hikariVersion = "3.3.1"
 val postgresVersion = "42.2.5"
+val kotliqueryVersion = "1.3.0"
 val junitJupiterVersion = "5.3.1"
 val testcontainers_version = "1.10.6"
 
@@ -52,6 +53,8 @@ dependencies {
     implementation("org.flywaydb:flyway-core:$flywayVersion")
     implementation("com.zaxxer:HikariCP:$hikariVersion")
     implementation("org.postgresql:postgresql:$postgresVersion")
+    implementation("de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.2.0")
+    implementation("com.github.seratch:kotliquery:$kotliqueryVersion")
 
     // Test
     testImplementation(kotlin("test"))

--- a/src/main/kotlin/no/nav/helse/inntektsmelding/App.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmelding/App.kt
@@ -8,6 +8,8 @@ private val log = LoggerFactory.getLogger(appName)
 fun main() {
     log.info("Starting $appName")
 
+
+
     Spinntektsmelding().start()
 }
 

--- a/src/main/kotlin/no/nav/helse/inntektsmelding/Spinntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmelding/Spinntektsmelding.kt
@@ -70,7 +70,7 @@ class Spinntektsmelding(env: Environment = Environment()) {
                     val externalAttachment = record.value()
                     if (externalAttachment.getServiceCode() == inntektsmeldingServiceCode && externalAttachment.getServiceEditionCode() == "1") {
                         val inntektsMelding = unwrapInntektsMelding(externalAttachment)
-                        logger.info("Fikk " + inntektsMelding)
+                        // TODO Lagre inntektsmeldingen
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/helse/inntektsmelding/Spinntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmelding/Spinntektsmelding.kt
@@ -69,7 +69,8 @@ class Spinntektsmelding(env: Environment = Environment()) {
                     logger.info("Prosesserer kafka record")
                     val externalAttachment = record.value()
                     if (externalAttachment.getServiceCode() == inntektsmeldingServiceCode && externalAttachment.getServiceEditionCode() == "1") {
-                        logger.info("Fikk " + unwrapInntektsMelding(externalAttachment))
+                        val inntektsMelding = unwrapInntektsMelding(externalAttachment)
+                        logger.info("Fikk " + inntektsMelding)
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/helse/inntektsmelding/db/InntektsmeldingStore.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmelding/db/InntektsmeldingStore.kt
@@ -1,0 +1,37 @@
+package no.nav.helse.inntektsmelding.db
+
+import de.huxhorn.sulky.ulid.ULID
+
+const val INNTEKTSMELDING_TABLE = "inntektsmelding_sykepenger"
+const val INNTEKTSMELDING_ID = "id"
+const val ARBEIDSGIVER_VIRKSOMHETSNUMMER = "arbeidsgiver_virksomhetsnummer"
+const val BRUKER_FNR = "bruker_fnr"
+const val ARBEIDSFORHOLD_ID = "arbeidsforhold_id"
+const val INNTEKTSMELDING_XML = "inntektsmelding_xml"
+const val XML_VERSJON = "xml_versjon"
+
+/** Represents a row in table inntektsmelding_sykepenger */
+data class StoredInntektsmelding(
+        val inntektsmeldingId: InntektsmeldingId,
+        val arbeidsgiverVirksomhetsnummer: String,
+        val brukerFnr: String,
+        val arbeidsforholdId: String,
+        val inntektsmeldingXml: String,
+        val xmlVersjon: String
+)
+
+data class InntektsmeldingId(val id: String) {
+    init {
+        try {
+            ULID.parseULID(id)
+        } catch (e: IllegalArgumentException) {
+            throw IllegalInntektsmeldingIdException("ID $id is not a valid ULID", e)
+        }
+    }
+}
+
+class InntektsmeldingNotFoundException(override val message: String) : RuntimeException(message)
+
+class StoreException(override val cause: Throwable) : RuntimeException(cause)
+
+class IllegalInntektsmeldingIdException(override val message: String, override val cause: Throwable) : RuntimeException(message, cause)

--- a/src/main/kotlin/no/nav/helse/inntektsmelding/db/PostgresInntektsmeldingStore.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmelding/db/PostgresInntektsmeldingStore.kt
@@ -1,0 +1,73 @@
+package no.nav.helse.inntektsmelding.db
+
+
+import de.huxhorn.sulky.ulid.ULID
+import kotliquery.queryOf
+import kotliquery.sessionOf
+import kotliquery.using
+import org.postgresql.util.PSQLException
+import javax.sql.DataSource
+
+class InntektsmeldingStore(private val dataSource: DataSource) {
+
+    private val ulidGenerator = ULID()
+
+    fun insertInntektsmelding(arbeidsgiverVirksomhetsnummer: String, brukerFnr: String, arbeidsforholdId: String,
+                              inntektsmeldingXml: String, xmlVersjon: String): StoredInntektsmelding {
+        try {
+            val inntektsmeldingId = InntektsmeldingId(ulidGenerator.nextULID())
+            using(sessionOf(dataSource)) { session ->
+                session.run(
+                        queryOf("INSERT INTO $INNTEKTSMELDING_TABLE " +
+                                "(" +
+                                "$INNTEKTSMELDING_ID, " +
+                                "$ARBEIDSGIVER_VIRKSOMHETSNUMMER, " +
+                                "$BRUKER_FNR, " +
+                                "$ARBEIDSFORHOLD_ID, " +
+                                "$INNTEKTSMELDING_XML, " +
+                                "$XML_VERSJON " +
+                                ") " +
+                                "VALUES (?, ?, ?, ?, ?, ?)",
+                                inntektsmeldingId.id,
+                                arbeidsgiverVirksomhetsnummer,
+                                brukerFnr,
+                                arbeidsforholdId,
+                                inntektsmeldingXml,
+                                xmlVersjon
+
+                        ).asUpdate
+                )
+            }
+            return getInntektsmelding(inntektsmeldingId)
+        } catch (p: PSQLException) {
+            throw StoreException(p)
+        }
+    }
+
+    fun getInntektsmelding(inntektsmeldingId: InntektsmeldingId): StoredInntektsmelding {
+        return using(sessionOf(dataSource)) { session ->
+            session.run(
+                    queryOf("SELECT $INNTEKTSMELDING_ID, " +
+                            "$ARBEIDSGIVER_VIRKSOMHETSNUMMER, " +
+                            "$BRUKER_FNR, " +
+                            "$ARBEIDSFORHOLD_ID, " +
+                            "$INNTEKTSMELDING_XML, " +
+                            "$XML_VERSJON " +
+                            "FROM $INNTEKTSMELDING_TABLE " +
+                            "WHERE $INNTEKTSMELDING_ID = ?", inntektsmeldingId.id)
+                            .map { row ->
+                                StoredInntektsmelding(
+                                        InntektsmeldingId(row.string(INNTEKTSMELDING_ID)),
+                                        row.string(ARBEIDSGIVER_VIRKSOMHETSNUMMER),
+                                        row.string(BRUKER_FNR),
+                                        row.string(ARBEIDSFORHOLD_ID),
+                                        row.string(INNTEKTSMELDING_XML),
+                                        row.string(XML_VERSJON)
+                                )
+                            }
+                            .asSingle
+            )
+                    ?: throw InntektsmeldingNotFoundException("Inntektsmelding with id $inntektsmeldingId not found.")
+        }
+    }
+}

--- a/src/main/resources/db/migration/V1__Create_tables.sql
+++ b/src/main/resources/db/migration/V1__Create_tables.sql
@@ -1,10 +1,11 @@
 CREATE TABLE IF NOT EXISTS inntektsmelding_sykepenger
 (
-  id                    TEXT                     NOT NULL,
-  ag_virksomhetsnummer  TEXT                     NOT NULL,
-  bruker_fnr            TEXT                     NOT NULL,
-  inntektsmelding_xml   TEXT                     NOT NULL,
-  xml_versjon           TEXT                     NOT NULL,
+  id                                TEXT                     NOT NULL,
+  arbeidsgiver_virksomhetsnummer    TEXT                     NOT NULL,
+  bruker_fnr                        TEXT                     NOT NULL,
+  arbeidsforhold_id                 TEXT                     NOT NULL,
+  inntektsmelding_xml               TEXT                     NOT NULL,
+  xml_versjon                       TEXT                     NOT NULL,
   created TIMESTAMP WITH TIME ZONE NOT NULL default (now() at time zone 'utc'),
   PRIMARY KEY (id)
 );


### PR DESCRIPTION
Lagrer inntektsmeldings-xml'en som tekst foreløpig, da den kan komme i opptil 3 litt forskjellige formater. 

Neste steg er å tolke disse tre formatene til en vettug datastruktur - Integrasjons-gutta anbefaler å drite i xsd'ene, og heller bruke xpath for å fiske ut det vesentligste.